### PR TITLE
Disable DRC and ERC in KiBot configuration

### DIFF
--- a/kibot.yaml
+++ b/kibot.yaml
@@ -22,7 +22,7 @@ variants:
 
 preflight:
   erc:
-    enabled: true
+    enabled: false
     warnings_as_errors: false
   drc:
     enabled: false


### PR DESCRIPTION
Disables the Electrical Rule Check (ERC) and Design Rule Check (DRC) in the `kibot.yaml` configuration file by setting `enabled: false` in the `preflight` section.

Fixes #1

---
*PR created automatically by Jules for task [6279556358380678281](https://jules.google.com/task/6279556358380678281) started by @chatelao*