### PR TITLE
Add minimal MakeCode Maker sketch for Raspberry Pi Pico

### DIFF
--- a/makecode/main.ts
+++ b/makecode/main.ts
@@ -1,0 +1,12 @@
+// Create a light strip with 256 WS2811 LEDs on GP3 (GPIO03)
+let strip = light.createStrip(pins.GP3, 256);
+
+// Set brightness
+strip.setBrightness(50);
+
+// Show a simple animation: a cycling rainbow
+forever(function () {
+    strip.showRainbow();
+    strip.rotate(1);
+    pause(50);
+});

--- a/makecode/pxt.json
+++ b/makecode/pxt.json
@@ -1,0 +1,16 @@
+{
+    "name": "pico-ws2811-demo",
+    "version": "0.0.0",
+    "description": "A minimal sketch to drive 256 WS2811 LEDs on GPIO03 of a Raspberry Pi Pico",
+    "files": [
+        "main.ts"
+    ],
+    "dependencies": {
+        "core": "*",
+        "light": "*"
+    },
+    "targetVersions": {
+        "target": "maker"
+    },
+    "preferredEditor": "tsprj"
+}


### PR DESCRIPTION
This change adds a minimal MakeCode Maker project in the `/makecode` directory. It includes a `pxt.json` manifest and a `main.ts` script. The script initializes a NeoPixel/WS2811 light strip with 256 LEDs on GPIO03 (referenced as `pins.GP3`) and runs a continuous rainbow animation. This provides a starting point for users wanting to drive LED matrices or strips with a Raspberry Pi Pico using the MakeCode Maker environment.

Fixes #3

---
*PR created automatically by Jules for task [11665339978915267225](https://jules.google.com/task/11665339978915267225) started by @chatelao*