### PR TITLE
Translate README.md to Swiss Standard German

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,65 @@
 # Aity Kids 4-LED Board
 
-This project provides a simple 4-LED board powered by a Seeed Studio XIAO RP2040 (or compatible XIAO module). It includes examples for both CircuitPython and Microsoft MakeCode Maker.
+Dieses Projekt bietet ein einfaches 4-LED-Board an, das mit einem Seeed Studio XIAO RP2040 (oder einem kompatiblen XIAO-Modul) betrieben wird. Es enthält Beispiele sowohl für CircuitPython als auch für den Microsoft MakeCode Maker.
 
-## Hardware Configuration
+## Hardware-Konfiguration
 
-- **Microcontroller**: Seeed Studio XIAO RP2040.
-- **NeoPixel Data Pin**: Connected to **D10** (which corresponds to **GP3** on the RP2040).
-- **LED Matrix**: Configured for a 16x16 matrix (256 LEDs) in the provided examples.
+- **Mikrocontroller**: Seeed Studio XIAO RP2040.
+- **NeoPixel-Datenpin**: Verbunden mit **D10** (entspricht **GP3** auf dem RP2040).
+- **LED-Matrix**: In den bereitgestellten Beispielen für eine 16x16-Matrix (256 LEDs) konfiguriert.
 
 <img width="616" height="432" alt="image" src="https://github.com/user-attachments/assets/f364a9d5-ba34-4fb9-b765-a625a0828113" />
 
 
-## Preparing the XIAO RP2040
+## Vorbereitung des XIAO RP2040
 
-To flash new firmware (CircuitPython or MakeCode) to the XIAO RP2040, you must first enter **Bootloader Mode**:
+Um eine neue Firmware (CircuitPython oder MakeCode) auf den XIAO RP2040 zu laden, müssen Sie zuerst in den **Bootloader-Modus** wechseln:
 
-1. Connect the XIAO RP2040 to your computer via USB.
-2. Press and hold the **BOOT** button (labeled 'B').
-3. While holding **BOOT**, press the **RESET** button (labeled 'R') once, or plug in the USB cable.
-4. Release the **BOOT** button.
-5. A new drive named `RPI-RP2` should appear on your computer.
+1. Verbinden Sie den XIAO RP2040 über USB mit Ihrem Computer.
+2. Drücken und halten Sie die **BOOT**-Taste (beschriftet mit 'B').
+3. Während Sie die **BOOT**-Taste gedrückt halten, drücken Sie einmal kurz die **RESET**-Taste (beschriftet mit 'R') oder stecken Sie das USB-Kabel ein.
+4. Lassen Sie die **BOOT**-Taste los.
+5. Ein neues Laufwerk mit dem Namen `RPI-RP2` sollte auf Ihrem Computer erscheinen.
 
 ---
 
 ## CircuitPython (CPy) Installation
 
-### 1. Install CircuitPython Firmware
-1. Download the latest CircuitPython UF2 file for the **Seeeduino XIAO RP2040** from [circuitpython.org](https://circuitpython.org/board/seeeduino_xiao_rp2040/).
-2. Enter Bootloader Mode (see above) so the `RPI-RP2` drive appears.
-3. Drag and drop the downloaded UF2 file onto the `RPI-RP2` drive.
-4. The board will reboot, and a new drive named `CIRCUITPY` will appear.
+### 1. CircuitPython-Firmware installieren
+1. Laden Sie die neueste CircuitPython-UF2-Datei für den **Seeeduino XIAO RP2040** von [circuitpython.org](https://circuitpython.org/board/seeeduino_xiao_rp2040/) herunter.
+2. Wechseln Sie in den Bootloader-Modus (siehe oben), damit das Laufwerk `RPI-RP2` erscheint.
+3. Ziehen Sie die heruntergeladene UF2-Datei per Drag-and-Drop auf das Laufwerk `RPI-RP2`.
+4. Das Board startet neu und ein neues Laufwerk mit dem Namen `CIRCUITPY` erscheint.
 
-### 2. Install Libraries
-CircuitPython requires external libraries to run the example.
-1. Download the [CircuitPython Library Bundle](https://circuitpython.org/libraries).
-2. Create a `lib` folder on your `CIRCUITPY` drive if it doesn't exist.
-3. Copy the following folders/files from the bundle to the `lib` folder:
-   - `adafruit_neopixel.mpy` (or the folder)
-   - `adafruit_imageload` (folder)
-   - `adafruit_display_text` (if needed by future expansions)
+### 2. Bibliotheken installieren
+CircuitPython benötigt externe Bibliotheken, um das Beispiel auszuführen.
+1. Laden Sie das [CircuitPython Library Bundle](https://circuitpython.org/libraries) herunter.
+2. Erstellen Sie einen Ordner namens `lib` auf Ihrem `CIRCUITPY`-Laufwerk, falls dieser noch nicht existiert.
+3. Kopieren Sie die folgenden Ordner/Dateien aus dem Bundle in den `lib`-Ordner:
+   - `adafruit_neopixel.mpy` (oder den Ordner)
+   - `adafruit_imageload` (Ordner)
+   - `adafruit_display_text` (falls für zukünftige Erweiterungen benötigt)
 
-### 3. Deploy the Code
-1. Copy the `code.py` file from the root of this repository to the `CIRCUITPY` drive.
-2. If the code requires an image, copy `image.png` to the root of the `CIRCUITPY` drive.
-3. The board will automatically reload and start running the script.
+### 3. Code bereitstellen
+1. Kopieren Sie die Datei `code.py` aus dem Stammverzeichnis dieses Repositories auf das `CIRCUITPY`-Laufwerk.
+2. Falls der Code ein Bild benötigt, kopieren Sie `image.png` in das Stammverzeichnis des `CIRCUITPY`-Laufwerks.
+3. Das Board lädt den Code automatisch neu und beginnt mit der Ausführung des Skripts.
 
 ---
 
-## MakeCode Installation
+## MakeCode-Installation
 
-Microsoft MakeCode Maker provides a block-based and TypeScript editor for the RP2040.
+Der Microsoft MakeCode Maker bietet einen blockbasierten Editor sowie einen TypeScript-Editor für den RP2040.
 
-### 1. Open the Project
-1. Go to [Microsoft MakeCode Maker](https://maker.makecode.com).
-2. Click on **Import**, then select **Import File...**.
-3. Choose the `makecode/pxt.json` or `makecode/main.ts` file from this repository.
-4. When prompted, select **Seeed Studio XIAO RP2040** as your board.
+### 1. Projekt öffnen
+1. Gehen Sie auf [Microsoft MakeCode Maker](https://maker.makecode.com).
+2. Klicken Sie auf **Import** und wählen Sie dann **Import File...** aus.
+3. Wählen Sie die Datei `makecode/pxt.json` oder `makecode/main.ts` aus diesem Repository aus.
+4. Wenn Sie dazu aufgefordert werden, wählen Sie **Seeed Studio XIAO RP2040** als Ihr Board aus.
 
-### 2. Download and Flash
-1. Click the **Download** button in the MakeCode editor.
-2. It will generate a `.uf2` file.
-3. Enter Bootloader Mode (see above) on your XIAO RP2040.
-4. Drag and drop the downloaded UF2 file onto the `RPI-RP2` drive.
-5. The board will reboot and immediately begin running your MakeCode program.
+### 2. Herunterladen und Flashen
+1. Klicken Sie auf die Schaltfläche **Download** im MakeCode-Editor.
+2. Es wird eine `.uf2`-Datei generiert.
+3. Wechseln Sie in den Bootloader-Modus (siehe oben) auf Ihrem XIAO RP2040.
+4. Ziehen Sie die heruntergeladene UF2-Datei per Drag-and-Drop auf das Laufwerk `RPI-RP2`.
+5. Das Board startet neu und beginnt sofort mit der Ausführung Ihres MakeCode-Programms.


### PR DESCRIPTION
The README.md file was translated from English to Swiss Standard German. This version follows Swiss orthographic rules (using 'ss' instead of 'ß') and maintains all technical documentation and instructions for the Aity Kids 4-LED board.

Fixes #10

---
*PR created automatically by Jules for task [14583599390118357980](https://jules.google.com/task/14583599390118357980) started by @chatelao*