### PR TITLE
Add Lesson 1 (LED Basics) directory and scripts

### DIFF
--- a/lektion-1/Lektionserläuterung.md
+++ b/lektion-1/Lektionserläuterung.md
@@ -1,0 +1,25 @@
+# Lektion 1: Erste Schritte mit dem 4-LED Board
+
+Willkommen zur ersten Lektion! In dieser Lektion lernst du, wie du die LEDs auf deinem Board mit CircuitPython steuerst.
+
+## Anleitung
+
+Um ein Programm auf deinem Board auszuführen, musst du die entsprechende Datei in `code.py` umbenennen und auf das `CIRCUITPY`-Laufwerk deines Microcontrollers kopieren.
+
+1. Wähle eine Datei aus (z.B. `code.00_one-led-on-board.py`).
+2. Benenne sie in `code.py` um.
+3. Kopiere sie auf das Board.
+4. Beobachte, was passiert!
+5. Ändere den Inhalt der Datei ein wenig (z.B. die Farben), um zu sehen, wie sich das Verhalten ändert.
+
+## Dateien in dieser Lektion
+
+Die Dateien sollten in der folgenden Reihenfolge angeschaut werden:
+
+1.  **code.00_one-led-on-board.py**: Schaltet die erste LED auf dem Board ein.
+2.  **code.01_three-led-on-board.py**: Schaltet die ersten drei LEDs in verschiedenen Farben ein.
+3.  **code.10_mini.py**: Ein ganz kurzes Minimalbeispiel.
+4.  **code.11_led-10x.py**: Schaltet insgesamt 10 LEDs ein.
+5.  **code.20_button.py**: Zeigt, wie man einen Knopf (Taster) benutzen kann, um die LED zu steuern.
+
+Viel Spaß beim Experimentieren!

--- a/lektion-1/code.00_one-led-on-board.py
+++ b/lektion-1/code.00_one-led-on-board.py
@@ -1,0 +1,12 @@
+import board
+import neopixel
+
+# Konfiguration: Pin D10 wird für die NeoPixel auf dem XIAO ESP32C3/RP2040 verwendet
+pixel_pin = board.D10
+num_pixels = 1
+
+# Initialisierung der NeoPixel
+pixels = neopixel.NeoPixel(pixel_pin, num_pixels, brightness=0.1, auto_write=True)
+
+# Die erste LED (Index 0) auf Rot setzen
+pixels[0] = (255, 0, 0)

--- a/lektion-1/code.01_three-led-on-board.py
+++ b/lektion-1/code.01_three-led-on-board.py
@@ -1,0 +1,14 @@
+import board
+import neopixel
+
+# Konfiguration: Pin D10 wird für die NeoPixel auf dem XIAO ESP32C3/RP2040 verwendet
+pixel_pin = board.D10
+num_pixels = 3
+
+# Initialisierung der NeoPixel
+pixels = neopixel.NeoPixel(pixel_pin, num_pixels, brightness=0.1, auto_write=True)
+
+# Die ersten drei LEDs auf unterschiedliche Farben setzen (Rot, Grün, Blau)
+pixels[0] = (255, 0, 0)
+pixels[1] = (0, 255, 0)
+pixels[2] = (0, 0, 255)

--- a/lektion-1/code.10_mini.py
+++ b/lektion-1/code.10_mini.py
@@ -1,0 +1,3 @@
+import board, neopixel
+pixels = neopixel.NeoPixel(board.D10, 1, brightness=0.05, auto_write=True)
+pixels[0] = (128, 0, 128) # Ein dezentes Lila

--- a/lektion-1/code.11_led-10x.py
+++ b/lektion-1/code.11_led-10x.py
@@ -1,0 +1,12 @@
+import board
+import neopixel
+
+# Konfiguration: Pin D10 wird für die NeoPixel auf dem XIAO ESP32C3/RP2040 verwendet
+pixel_pin = board.D10
+num_pixels = 10
+
+# Initialisierung der NeoPixel
+pixels = neopixel.NeoPixel(pixel_pin, num_pixels, brightness=0.1, auto_write=True)
+
+# Alle 10 LEDs auf Orange setzen
+pixels.fill((255, 100, 0))

--- a/lektion-1/code.20_button.py
+++ b/lektion-1/code.20_button.py
@@ -1,0 +1,24 @@
+import board
+import neopixel
+import digitalio
+import time
+
+# NeoPixel Konfiguration
+pixel_pin = board.D10
+pixels = neopixel.NeoPixel(pixel_pin, 1, brightness=0.1, auto_write=True)
+
+# Button Konfiguration (Passe den Pin an, falls nötig, z.B. D0)
+button_pin = board.D0
+button = digitalio.DigitalInOut(button_pin)
+button.direction = digitalio.Direction.INPUT
+button.pull = digitalio.Pull.UP # Interner Pull-Up Widerstand
+
+print("Drücke den Knopf, um die LED-Farbe zu ändern!")
+
+while True:
+    if not button.value: # Wenn der Knopf gedrückt wird (Low-Signal wegen Pull-Up)
+        pixels[0] = (0, 255, 0) # Grün
+    else:
+        pixels[0] = (255, 0, 0) # Rot
+
+    time.sleep(0.01) # Kurze Pause zum Entprellen


### PR DESCRIPTION
I have created the requested `/lektion-1` directory and populated it with the lesson explanation file and the five CircuitPython scripts as specified. The scripts use the NeoPixel configuration on pin D10 (common for XIAO boards) and follow the requested naming and sequence. I also verified the syntax and cleaned up any build artifacts.

Fixes #11

---
*PR created automatically by Jules for task [16559767481637687441](https://jules.google.com/task/16559767481637687441) started by @chatelao*