### PR TITLE
Add ASCII-Pinout drawing and fix documentation inconsistency in Lektion 2

### DIFF
--- a/lektion-2/README.md
+++ b/lektion-2/README.md
@@ -15,10 +15,10 @@ Verbinde deinen Arcade-Joystick gemäss der folgenden Tabelle mit dem XIAO RP204
 
 | Arcade-Eingang | XIAO Pin | GP-Nummer |
 | :--- | :--- | :--- |
-| Joystick Oben | **D0** | GP26 |
-| Joystick Unten | **D1** | GP27 |
-| Joystick Links | **D4** | GP06 |
-| Joystick Rechts | **D5** | GP07 |
+| Joystick Oben | **D2** | GP28 |
+| Joystick Unten | **D3** | GP29 |
+| Joystick Links | **D1** | GP27 |
+| Joystick Rechts | **D0** | GP26 |
 | Gemeinsame Masse | **GND** | GND |
 
 ---

--- a/lektion-2/code.00_joystick_print.py
+++ b/lektion-2/code.00_joystick_print.py
@@ -2,6 +2,19 @@ import board
 import digitalio
 import time
 
+#  Arcade Joystick Pinout:
+#
+#        XIAO RP2040                        Joystick (5-Pin)
+#      +--------------+                    +----------------+
+#      | [ ] D0  -----+--------------------| (2) Rechts     |
+#      | [ ] D1  -----+--------------------| (1) Links      |
+#      | [ ] D2  -----+--------------------| (3) Oben       |
+#      | [ ] D3  -----+--------------------| (4) Unten      |
+#      | [ ] D4       |                    | (5) Masse (GND)|
+#      | [ ] D5       |                    +--------|-------+
+#      | [ ] GND -----+-----------------------------+
+#      +--------------+
+
 # Pin-Konfiguration für den Arcade-Controller
 # Wir verwenden interne Pull-Up Widerstände, daher ist der Wert 'False', wenn gedrückt.
 # Mapping: Oben=D2, Unten=D3, Links=D1, Rechts=D0


### PR DESCRIPTION
This PR adds a helpful ASCII-based wiring diagram to the first joystick lesson (`lektion-2/code.00_joystick_print.py`). While implementing this, I discovered and fixed an inconsistency in the `lektion-2/README.md` where the pinout table did not match the functional code. Both the ASCII art and the README table now correctly reflect the pin mapping: D0=Right, D1=Left, D2=Up, D3=Down.

Fixes #19

---
*PR created automatically by Jules for task [16721259568214731167](https://jules.google.com/task/16721259568214731167) started by @chatelao*