### PR TITLE
Add ASCII Pinout and Correct Joystick Mappings for Lesson 2

### DIFF
--- a/lektion-2/code.00_joystick_print.py
+++ b/lektion-2/code.00_joystick_print.py
@@ -2,15 +2,27 @@ import board
 import digitalio
 import time
 
+#      XIAO RP2040 Pinout & Joystick Wiring
+#
+#             +--------------+
+# (Oben)   D0 | [ ]      [ ] | 5V
+# (Unten)  D1 | [ ]      [ ] | GND <--- Common (GND)
+#          D2 | [ ]      [ ] | 3V3
+#          D3 | [ ]      [ ] | D10 (NeoPixel Matrix)
+# (Links)  D4 | [ ]      [ ] | D9
+# (Rechts) D5 | [ ]      [ ] | D8
+#          D6 | [ ]      [ ] | D7
+#             +-----USB------+
+
 # Pin-Konfiguration für den Arcade-Controller
 # Wir verwenden interne Pull-Up Widerstände, daher ist der Wert 'False', wenn gedrückt.
-# Mapping: Oben=D2, Unten=D3, Links=D1, Rechts=D0
+# Mapping laut README: Oben=D0, Unten=D1, Links=D4, Rechts=D5
 
 pins = {
-    "Oben": board.D2,
-    "Unten": board.D3,
-    "Links": board.D1,
-    "Rechts": board.D0
+    "Oben": board.D0,
+    "Unten": board.D1,
+    "Links": board.D4,
+    "Rechts": board.D5
 }
 
 # Initialisierung der Eingabestifte

--- a/lektion-2/code.01_pixel_move.py
+++ b/lektion-2/code.01_pixel_move.py
@@ -10,10 +10,11 @@ HEIGHT = 16
 pixels = neopixel.NeoPixel(PIXEL_PIN, WIDTH * HEIGHT, brightness=0.1, auto_write=False)
 
 # Joystick Konfiguration
-up = digitalio.DigitalInOut(board.D2)
-down = digitalio.DigitalInOut(board.D3)
-left = digitalio.DigitalInOut(board.D1)
-right = digitalio.DigitalInOut(board.D0)
+# Mapping laut README: Oben=D0, Unten=D1, Links=D4, Rechts=D5
+up = digitalio.DigitalInOut(board.D0)
+down = digitalio.DigitalInOut(board.D1)
+left = digitalio.DigitalInOut(board.D4)
+right = digitalio.DigitalInOut(board.D5)
 
 for pin in [up, down, left, right]:
     pin.direction = digitalio.Direction.INPUT

--- a/lektion-2/code.10_mini_game.py
+++ b/lektion-2/code.10_mini_game.py
@@ -11,10 +11,11 @@ HEIGHT = 16
 pixels = neopixel.NeoPixel(PIXEL_PIN, WIDTH * HEIGHT, brightness=0.1, auto_write=False)
 
 # Eingabe Konfiguration
-up = digitalio.DigitalInOut(board.D2)
-down = digitalio.DigitalInOut(board.D3)
-left = digitalio.DigitalInOut(board.D1)
-right = digitalio.DigitalInOut(board.D0)
+# Mapping laut README: Oben=D0, Unten=D1, Links=D4, Rechts=D5
+up = digitalio.DigitalInOut(board.D0)
+down = digitalio.DigitalInOut(board.D1)
+left = digitalio.DigitalInOut(board.D4)
+right = digitalio.DigitalInOut(board.D5)
 
 for pin in [up, down, left, right]:
     pin.direction = digitalio.Direction.INPUT


### PR DESCRIPTION
This change adds a helpful ASCII pinout diagram to the first script of Lesson 2, making it easier for users to verify their wiring. Additionally, it corrects the pin constants across all scripts in the lesson to ensure they match the physical wiring instructions provided in the README and images.

Fixes #20

---
*PR created automatically by Jules for task [11684166627694802180](https://jules.google.com/task/11684166627694802180) started by @chatelao*